### PR TITLE
layout should have max-width to work better on desktop

### DIFF
--- a/frontend/src/components/AlterBookingDrawer.tsx
+++ b/frontend/src/components/AlterBookingDrawer.tsx
@@ -192,80 +192,97 @@ const AlterBookingDrawer = (props: Props) => {
             toggle={toggle}
             disableSwipeToOpen={true}
         >
-            <DrawerContent>
-                <RowCentered>
-                    <TimeTextBoldGreen>
-                        {duration} min remaning
-                    </TimeTextBoldGreen>
-                </RowCentered>
-                <RowCentered>
-                    <AvailableTextGreen>
-                        Room booked for you untill {getSimpleEndTime(booking)}
-                    </AvailableTextGreen>
-                </RowCentered>
-                <RowCentered>
-                    <AvailableText>
-                        {minutesToSimpleString(availableMinutes)} more available
-                    </AvailableText>
-                </RowCentered>
+            <Box
+                style={{
+                    width: '100%',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center'
+                }}
+            >
+                <DrawerContent>
+                    <RowCentered>
+                        <TimeTextBoldGreen>
+                            {duration} min remaning
+                        </TimeTextBoldGreen>
+                    </RowCentered>
+                    <RowCentered>
+                        <AvailableTextGreen>
+                            Room booked for you untill{' '}
+                            {getSimpleEndTime(booking)}
+                        </AvailableTextGreen>
+                    </RowCentered>
+                    <RowCentered>
+                        <AvailableText>
+                            {minutesToSimpleString(availableMinutes)} more
+                            available
+                        </AvailableText>
+                    </RowCentered>
 
-                <Row>
-                    <SmallText>alter booking (rounded to next 5 min)</SmallText>
-                </Row>
-                <Row>
-                    <DrawerButtonPrimary
-                        aria-label="subtract 15 minutes"
-                        data-testid="subtract15"
-                        onClick={(e) => handleAdditionalTime(-15)}
-                        disabled={disableSubtractTime()}
-                    >
-                        <RemoveIcon /> 15 min
-                    </DrawerButtonPrimary>
-                    <Spacer />
-                    <DrawerButtonPrimary
-                        aria-label="add 15 minutes"
-                        data-testid="add15"
-                        onClick={(e) => handleAdditionalTime(15)}
-                        disabled={disableAddTime()}
-                    >
-                        <AddIcon /> 15 min
-                    </DrawerButtonPrimary>
-                </Row>
-                <Row>
-                    <DrawerButtonSecondary
-                        aria-label="next half hour"
-                        onClick={handleNextHalfHour}
-                        disabled={disableNextHalfHour()}
-                    >
-                        {nextHalfHour().toLocaleString(DateTime.TIME_24_SIMPLE)}
-                    </DrawerButtonSecondary>
-                    <Spacer />
-                    <DrawerButtonSecondary
-                        aria-label="next full hour"
-                        onClick={handleNextFullHour}
-                        disabled={disableNextFullHour()}
-                    >
-                        {nextFullHour().toLocaleString(DateTime.TIME_24_SIMPLE)}
-                    </DrawerButtonSecondary>
-                </Row>
-                <Row>
-                    <DrawerButtonSecondary
-                        aria-label="untill next meeting"
-                        onClick={handleUntillNextMeeting}
-                    >
-                        Untill next meeting
-                    </DrawerButtonSecondary>
-                </Row>
-                <Row>
-                    <DrawerButtonPrimary
-                        aria-label="End booking"
-                        data-testid="EndBookingButton"
-                        onClick={handleEndBooking}
-                    >
-                        End Booking
-                    </DrawerButtonPrimary>
-                </Row>
-            </DrawerContent>
+                    <Row>
+                        <SmallText>
+                            alter booking (rounded to next 5 min)
+                        </SmallText>
+                    </Row>
+                    <Row>
+                        <DrawerButtonPrimary
+                            aria-label="subtract 15 minutes"
+                            data-testid="subtract15"
+                            onClick={(e) => handleAdditionalTime(-15)}
+                            disabled={disableSubtractTime()}
+                        >
+                            <RemoveIcon /> 15 min
+                        </DrawerButtonPrimary>
+                        <Spacer />
+                        <DrawerButtonPrimary
+                            aria-label="add 15 minutes"
+                            data-testid="add15"
+                            onClick={(e) => handleAdditionalTime(15)}
+                            disabled={disableAddTime()}
+                        >
+                            <AddIcon /> 15 min
+                        </DrawerButtonPrimary>
+                    </Row>
+                    <Row>
+                        <DrawerButtonSecondary
+                            aria-label="next half hour"
+                            onClick={handleNextHalfHour}
+                            disabled={disableNextHalfHour()}
+                        >
+                            {nextHalfHour().toLocaleString(
+                                DateTime.TIME_24_SIMPLE
+                            )}
+                        </DrawerButtonSecondary>
+                        <Spacer />
+                        <DrawerButtonSecondary
+                            aria-label="next full hour"
+                            onClick={handleNextFullHour}
+                            disabled={disableNextFullHour()}
+                        >
+                            {nextFullHour().toLocaleString(
+                                DateTime.TIME_24_SIMPLE
+                            )}
+                        </DrawerButtonSecondary>
+                    </Row>
+                    <Row>
+                        <DrawerButtonSecondary
+                            aria-label="untill next meeting"
+                            onClick={handleUntillNextMeeting}
+                        >
+                            Untill next meeting
+                        </DrawerButtonSecondary>
+                    </Row>
+                    <Row>
+                        <DrawerButtonPrimary
+                            aria-label="End booking"
+                            data-testid="EndBookingButton"
+                            onClick={handleEndBooking}
+                        >
+                            End Booking
+                        </DrawerButtonPrimary>
+                    </Row>
+                </DrawerContent>
+            </Box>
         </SwipeableEdgeDrawer>
     );
 };

--- a/frontend/src/components/BookingDrawer.tsx
+++ b/frontend/src/components/BookingDrawer.tsx
@@ -248,77 +248,88 @@ const BookingDrawer = (props: Props) => {
             toggle={toggle}
             disableSwipeToOpen={true}
         >
-            <DrawerContent>
-                <RowCentered>
-                    <TimeTextBold>
-                        {minutesToSimpleString(duration + additionalDuration)}
-                    </TimeTextBold>
-                    <TimeText>
-                        {getBookingRangeText(duration + additionalDuration)}
-                    </TimeText>
-                </RowCentered>
-                <RowCentered>
-                    <AvailableText>
-                        Maximum {getTimeAvailable(room)} available
-                    </AvailableText>
-                </RowCentered>
-                <Row>
-                    <SmallText>booking (rounded to next 5 min)</SmallText>
-                </Row>
-                <Row>
-                    <DrawerButtonPrimary
-                        aria-label="subtract 15 minutes"
-                        data-testid="subtract15"
-                        onClick={(e) => handleAdditionalTime(-15)}
-                        disabled={disableSubtractTime()}
-                    >
-                        <RemoveIcon /> 15 min
-                    </DrawerButtonPrimary>
-                    <Spacer />
-                    <DrawerButtonPrimary
-                        aria-label="add 15 minutes"
-                        data-testid="add15"
-                        onClick={(e) => handleAdditionalTime(15)}
-                        disabled={disableAddTime()}
-                    >
-                        <AddIcon /> 15 min
-                    </DrawerButtonPrimary>
-                </Row>
-                <Row>
-                    <DrawerButtonSecondary
-                        onClick={() => handleNextHalfHour()}
-                        disabled={disableNextHalfHour()}
-                    >
-                        Until {nextHalfHour}
-                    </DrawerButtonSecondary>
-                    <Spacer />
-                    <DrawerButtonSecondary
-                        onClick={() => handleNextFullHour()}
-                        disabled={disableNextFullHour()}
-                    >
-                        Until {nextFullHour}
-                    </DrawerButtonSecondary>
-                </Row>
-                <Row>
-                    <DrawerButtonSecondary
-                        aria-label="until next meeting"
-                        onClick={() =>
-                            handleUntilNext(getTimeAvailableMinutes(room))
-                        }
-                    >
-                        Until next meeting
-                    </DrawerButtonSecondary>
-                </Row>
-                <Row>
-                    <DrawerButtonPrimary
-                        aria-label="book now"
-                        data-testid="BookNowButton"
-                        onClick={bookRoom}
-                    >
-                        Book now
-                    </DrawerButtonPrimary>
-                </Row>
-            </DrawerContent>
+            <Box
+                style={{
+                    width: '100%',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center'
+                }}
+            >
+                <DrawerContent>
+                    <RowCentered>
+                        <TimeTextBold>
+                            {minutesToSimpleString(
+                                duration + additionalDuration
+                            )}
+                        </TimeTextBold>
+                        <TimeText>
+                            {getBookingRangeText(duration + additionalDuration)}
+                        </TimeText>
+                    </RowCentered>
+                    <RowCentered>
+                        <AvailableText>
+                            Maximum {getTimeAvailable(room)} available
+                        </AvailableText>
+                    </RowCentered>
+                    <Row>
+                        <SmallText>booking (rounded to next 5 min)</SmallText>
+                    </Row>
+                    <Row>
+                        <DrawerButtonPrimary
+                            aria-label="subtract 15 minutes"
+                            data-testid="subtract15"
+                            onClick={(e) => handleAdditionalTime(-15)}
+                            disabled={disableSubtractTime()}
+                        >
+                            <RemoveIcon /> 15 min
+                        </DrawerButtonPrimary>
+                        <Spacer />
+                        <DrawerButtonPrimary
+                            aria-label="add 15 minutes"
+                            data-testid="add15"
+                            onClick={(e) => handleAdditionalTime(15)}
+                            disabled={disableAddTime()}
+                        >
+                            <AddIcon /> 15 min
+                        </DrawerButtonPrimary>
+                    </Row>
+                    <Row>
+                        <DrawerButtonSecondary
+                            onClick={() => handleNextHalfHour()}
+                            disabled={disableNextHalfHour()}
+                        >
+                            Until {nextHalfHour}
+                        </DrawerButtonSecondary>
+                        <Spacer />
+                        <DrawerButtonSecondary
+                            onClick={() => handleNextFullHour()}
+                            disabled={disableNextFullHour()}
+                        >
+                            Until {nextFullHour}
+                        </DrawerButtonSecondary>
+                    </Row>
+                    <Row>
+                        <DrawerButtonSecondary
+                            aria-label="until next meeting"
+                            onClick={() =>
+                                handleUntilNext(getTimeAvailableMinutes(room))
+                            }
+                        >
+                            Until next meeting
+                        </DrawerButtonSecondary>
+                    </Row>
+                    <Row>
+                        <DrawerButtonPrimary
+                            aria-label="book now"
+                            data-testid="BookNowButton"
+                            onClick={bookRoom}
+                        >
+                            Book now
+                        </DrawerButtonPrimary>
+                    </Row>
+                </DrawerContent>
+            </Box>
         </SwipeableEdgeDrawer>
     );
 };

--- a/frontend/src/components/BookingView.tsx
+++ b/frontend/src/components/BookingView.tsx
@@ -383,17 +383,29 @@ function BookingView(props: BookingViewProps) {
                     toggle={toggle}
                     disableSwipeToOpen={true}
                 >
-                    <DrawerContent>
-                        <RowCentered>
-                            <Typography
-                                variant="body1"
-                                sx={{ color: '#000000', font: 'Roboto Mono' }}
-                            >
-                                {preferences?.building?.name} was selected as
-                                your office based on your GPS location
-                            </Typography>
-                        </RowCentered>
-                    </DrawerContent>
+                    <Box
+                        style={{
+                            width: '100%',
+                            display: 'flex',
+                            flexDirection: 'column',
+                            alignItems: 'center'
+                        }}
+                    >
+                        <DrawerContent>
+                            <RowCentered>
+                                <Typography
+                                    variant="body1"
+                                    sx={{
+                                        color: '#000000',
+                                        font: 'Roboto Mono'
+                                    }}
+                                >
+                                    {preferences?.building?.name} was selected
+                                    as your office based on your GPS location
+                                </Typography>
+                            </RowCentered>
+                        </DrawerContent>
+                    </Box>
                 </SwipeableEdgeDrawer>
             </div>
 

--- a/frontend/src/components/FilteringDrawer.tsx
+++ b/frontend/src/components/FilteringDrawer.tsx
@@ -120,75 +120,84 @@ const FilteringDrawer = (props: Props) => {
             disableSwipeToOpen={false}
             mounted={true}
         >
-            <DrawerContent>
-                <Row>
-                    <SmallText>Custom Filter</SmallText>
-                </Row>
-                <TextField
-                    onChange={handleCustomFilter}
-                    value={customFilter}
-                    placeholder="Room name, resource..."
-                    size="small"
-                    InputProps={{
-                        startAdornment: (
-                            <InputAdornment position="start">
-                                <SearchIcon />
-                            </InputAdornment>
-                        )
-                    }}
-                />
+            <Box
+                style={{
+                    width: '100%',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center'
+                }}
+            >
+                <DrawerContent>
+                    <Row>
+                        <SmallText>Custom Filter</SmallText>
+                    </Row>
+                    <TextField
+                        onChange={handleCustomFilter}
+                        value={customFilter}
+                        placeholder="Room name, resource..."
+                        size="small"
+                        InputProps={{
+                            startAdornment: (
+                                <InputAdornment position="start">
+                                    <SearchIcon />
+                                </InputAdornment>
+                            )
+                        }}
+                    />
 
-                <Row>
-                    <SmallText>Custom Duration (Minutes)</SmallText>
-                </Row>
+                    <Row>
+                        <SmallText>Custom Duration (Minutes)</SmallText>
+                    </Row>
 
-                <TextField
-                    size="small"
-                    type="number"
-                    placeholder="Give duration in minutes"
-                    inputProps={{ min: 0, max: 1439 }}
-                    value={duration}
-                    onChange={handleCustomDuration}
-                />
+                    <TextField
+                        size="small"
+                        type="number"
+                        placeholder="Give duration in minutes"
+                        inputProps={{ min: 0, max: 1439 }}
+                        value={duration}
+                        onChange={handleCustomDuration}
+                    />
 
-                <Row>
-                    <SmallText>Room Size (People)</SmallText>
-                </Row>
-                <StyledToggleButtonGroup
-                    value={roomSize}
-                    onChange={handleRoomSizeChange}
-                >
-                    <ToggleButton value="1-2">1-2</ToggleButton>
-                    <ToggleButton value="3-5">3-5</ToggleButton>
-                    <ToggleButton value="6-7">6-7</ToggleButton>
-                    <ToggleButton value="8-99999">8+</ToggleButton>
-                </StyledToggleButtonGroup>
-                <Row>
-                    <SmallText>Resources</SmallText>
-                </Row>
-                <StyledToggleButtonGroup
-                    value={resources}
-                    onChange={handleResourcesChange}
-                    sx={{ minHeight: '56px' }}
-                >
-                    {allFeatures.map((feature) => (
-                        <ToggleButton key={feature} value={feature}>
-                            {feature}
-                        </ToggleButton>
-                    ))}
-                </StyledToggleButtonGroup>
-                <Row>
-                    <SmallText>Favourites</SmallText>
-                </Row>
-                <ToggleButton
-                    value="favourites"
-                    selected={onlyFavourites}
-                    onChange={() => setOnlyFavourites(!onlyFavourites)}
-                >
-                    <FavoriteBorderIcon />
-                    &nbsp; Only Favourites
-                </ToggleButton>
-            </DrawerContent>
+                    <Row>
+                        <SmallText>Room Size (People)</SmallText>
+                    </Row>
+                    <StyledToggleButtonGroup
+                        value={roomSize}
+                        onChange={handleRoomSizeChange}
+                    >
+                        <ToggleButton value="1-2">1-2</ToggleButton>
+                        <ToggleButton value="3-5">3-5</ToggleButton>
+                        <ToggleButton value="6-7">6-7</ToggleButton>
+                        <ToggleButton value="8-99999">8+</ToggleButton>
+                    </StyledToggleButtonGroup>
+                    <Row>
+                        <SmallText>Resources</SmallText>
+                    </Row>
+                    <StyledToggleButtonGroup
+                        value={resources}
+                        onChange={handleResourcesChange}
+                        sx={{ minHeight: '56px' }}
+                    >
+                        {allFeatures.map((feature) => (
+                            <ToggleButton key={feature} value={feature}>
+                                {feature}
+                            </ToggleButton>
+                        ))}
+                    </StyledToggleButtonGroup>
+                    <Row>
+                        <SmallText>Favourites</SmallText>
+                    </Row>
+                    <ToggleButton
+                        value="favourites"
+                        selected={onlyFavourites}
+                        onChange={() => setOnlyFavourites(!onlyFavourites)}
+                    >
+                        <FavoriteBorderIcon />
+                        &nbsp; Only Favourites
+                    </ToggleButton>
+                </DrawerContent>
+            </Box>
         </SwipeableEdgeDrawer>
     );
 };

--- a/frontend/src/components/MainView.tsx
+++ b/frontend/src/components/MainView.tsx
@@ -84,11 +84,12 @@ const MainView = () => {
             id="main-view"
             display="flex"
             flexDirection="column"
-            height="100vh"
+            minHeight="100vh"
+            alignItems="center"
         >
             <Box
                 id="main-view-content"
-                sx={{ flexGrow: 1, overflowY: 'scroll' }}
+                sx={{ flexGrow: 1, maxWidth: '1000px', width: '100%' }}
             >
                 <Switch>
                     <Route path="/(preferences|auth/success)/">

--- a/frontend/src/components/SwipeableEdgeDrawer.tsx
+++ b/frontend/src/components/SwipeableEdgeDrawer.tsx
@@ -35,8 +35,7 @@ const Puller = styled(Box)(({ theme }) => ({
 const DrawerHeader = styled(Box)(({ theme }) => ({
     padding: '24px',
     display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'center',
+    justifyContent: 'center',
     position: 'absolute',
     top: -drawerBleeding,
     borderTopLeftRadius: 40,
@@ -76,7 +75,9 @@ export const DrawerContent = styled(Box)(({ theme }) => ({
     display: 'flex',
     flexDirection: 'column',
     height: '100%',
-    margin: '0 24px 24px 24px'
+    margin: '0 24px 24px 24px',
+    width: 'calc(100% - 48px)',
+    maxWidth: '1000px'
 }));
 
 interface Props {
@@ -176,21 +177,35 @@ const SwipeableEdgeDrawer = (props: Props) => {
                 swipeAreaWidth={drawerBleeding}
                 disableSwipeToOpen={disableSwipeToOpen}
                 keepMounted={mounted}
+                style={{
+                    position: 'relative',
+                    width: '100%',
+                    maxWidth: '1000px'
+                }}
             >
                 <DrawerHeader onClick={handleHeaderClick}>
-                    {left}
-                    <Puller />
-                    {title}
-                    {filters}
-                    <Puller />
-                    <IconButton
-                        onClick={toggleDrawer(false)}
-                        aria-label={label}
+                    <Box
+                        style={{
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            alignItems: 'center',
+                            width: '100%',
+                            maxWidth: '1000px'
+                        }}
                     >
-                        {right}
-                    </IconButton>
+                        {left}
+                        <Puller />
+                        {title}
+                        {filters}
+                        <Puller />
+                        <IconButton
+                            onClick={toggleDrawer(false)}
+                            aria-label={label}
+                        >
+                            {right}
+                        </IconButton>
+                    </Box>
                 </DrawerHeader>
-
                 {children}
             </SwipeableDrawer>
         </Root>

--- a/frontend/src/components/UserDrawer.tsx
+++ b/frontend/src/components/UserDrawer.tsx
@@ -4,6 +4,7 @@ import SwipeableEdgeDrawer, { DrawerContent } from './SwipeableEdgeDrawer';
 import { DrawerButtonSecondary } from './BookingDrawer';
 import { logout } from '../services/authService';
 import useCreateNotification from '../hooks/useCreateNotification';
+import { Box } from '@mui/material';
 
 type userSettingsProps = {
     open: boolean;
@@ -45,23 +46,32 @@ const UserDrawer = (props: userSettingsProps) => {
             toggle={toggle}
             disableSwipeToOpen={true}
         >
-            <DrawerContent>
-                <DrawerButtonSecondary
-                    aria-label="settings drawer "
-                    data-testid="BookNowButton"
-                    onClick={handleAllFeaturesCollapse}
-                >
-                    <Visibility aria-label="visibility" />
-                    &nbsp;Show room resources
-                </DrawerButtonSecondary>
-                <DrawerButtonSecondary
-                    aria-label="logout"
-                    data-testid="BookNowButton"
-                    onClick={doLogout}
-                >
-                    logout
-                </DrawerButtonSecondary>
-            </DrawerContent>
+            <Box
+                style={{
+                    width: '100%',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center'
+                }}
+            >
+                <DrawerContent>
+                    <DrawerButtonSecondary
+                        aria-label="settings drawer "
+                        data-testid="BookNowButton"
+                        onClick={handleAllFeaturesCollapse}
+                    >
+                        <Visibility aria-label="visibility" />
+                        &nbsp;Show room resources
+                    </DrawerButtonSecondary>
+                    <DrawerButtonSecondary
+                        aria-label="logout"
+                        data-testid="BookNowButton"
+                        onClick={doLogout}
+                    >
+                        logout
+                    </DrawerButtonSecondary>
+                </DrawerContent>
+            </Box>
         </SwipeableEdgeDrawer>
     );
 };


### PR DESCRIPTION
- Set maxWidth property of the main content to 1000px so that the elements will not expand 100% width of the screen, which annoys when the screen is large. 

Here are some screenshots of how the UI would look on a standard 1920x1080px desktop screen.

![image](https://user-images.githubusercontent.com/65652588/194916337-6018dec6-430f-4295-95e3-bf4301827aa6.png)
![image](https://user-images.githubusercontent.com/65652588/194916410-9e3575f8-33df-43a3-8980-9d55dc2a0c9b.png)
![image](https://user-images.githubusercontent.com/65652588/194916447-34c642b4-7587-47f4-9938-65b9d1e5c54f.png)
![image](https://user-images.githubusercontent.com/65652588/194916477-123ffbea-84d9-410b-8916-c316776c5e84.png)
![image](https://user-images.githubusercontent.com/65652588/194916529-b6d24d1c-114b-42ba-90d8-23a105a4e5c9.png)



