### PR TITLE
Fix start time picker drawer visibility

### DIFF
--- a/frontend/src/components/StartingTimePickerDrawer/StartingTimePickerDrawer.tsx
+++ b/frontend/src/components/StartingTimePickerDrawer/StartingTimePickerDrawer.tsx
@@ -77,7 +77,7 @@ const StartingTimePickerDrawer = (props: StartingTimePickerDrawerProps) => {
             isOpen={open}
             toggle={toggle}
             disableSwipeToOpen={true}
-            zindex={1200}
+            zindex={1201}
         >
             <Box
                 style={{


### PR DESCRIPTION
The custom starting time picker drawer was partly overlapped by the filter menu. Increased the z-index of start time picker drawer to correctly show the entirety of the component when opened.